### PR TITLE
[#39 Breaking change] Caught Items One By One

### DIFF
--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -118,38 +118,43 @@ func UpdateUserFish(c *fiber.Ctx) error {
 			"message": "unauthenticated",
 		})
 	} else {
-		var updateActualUser models.User
+		claims := token.Claims.(*jwt.RegisteredClaims)
+		database.DB.Db.Where("id=?", claims.Issuer).First(&actualUser)
+
+		type UpdateUserCaughtFish struct {
+			FishNumber int32 `json:"caught_fish"`
+		}
+
+		updateActualUser := new(UpdateUserCaughtFish)
 		errActual := c.BodyParser(&updateActualUser)
-		if errActual != nil {
+
+		if errActual == nil && updateActualUser.FishNumber == 0 {
 			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 				"status":  "error",
 				"message": "Something's wrong with your input",
 				"data":    errActual,
 			})
-		}
+		} else {
+			// Check if updated fields aren't over the maximum range of resources
+			maxBugAndFish := int32(80)
 
-		// Check if updated fields aren't over the maximum range of resources
-		maxBugAndFish := int32(80)
-
-		for _, fish := range updateActualUser.CaughtFish {
-			if fish > maxBugAndFish {
+			if updateActualUser.FishNumber > maxBugAndFish {
 				return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 					"status":  "error",
 					"message": "Fish is out of range (maximum 80 items)",
 					"data":    errActual,
 				})
 			}
+
+			// Fields to update
+			actualUser.CaughtFish = append(actualUser.CaughtFish, updateActualUser.FishNumber)
+
+			database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
+			return c.Status(fiber.StatusOK).JSON(fiber.Map{
+				"status":  "success",
+				"message": "user updated",
+			})
 		}
-
-		// Fields to update
-		actualUser.CaughtFish = updateActualUser.CaughtFish
-
-		claims := token.Claims.(*jwt.RegisteredClaims)
-		database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
-		return c.Status(fiber.StatusOK).JSON(fiber.Map{
-			"status":  "success",
-			"message": "user updated",
-		})
 	}
 }
 
@@ -168,38 +173,44 @@ func UpdateUserBug(c *fiber.Ctx) error {
 			"message": "unauthenticated",
 		})
 	} else {
-		var updateActualUser models.User
+		claims := token.Claims.(*jwt.RegisteredClaims)
+		database.DB.Db.Where("id=?", claims.Issuer).First(&actualUser)
+
+		type UpdateUserCaughtBug struct {
+			BugNumber int32 `json:"caught_bug"`
+		}
+
+		updateActualUser := new(UpdateUserCaughtBug)
 		errActual := c.BodyParser(&updateActualUser)
-		if errActual != nil {
+
+		if errActual == nil && updateActualUser.BugNumber == 0 {
 			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 				"status":  "error",
 				"message": "Something's wrong with your input",
 				"data":    errActual,
 			})
-		}
+		} else {
+			// Check if updated fields aren't over the maximum range of resources
+			maxBugAndFish := int32(80)
 
-		// Check if updated fields aren't over the maximum range of resources
-		maxBugAndFish := int32(80)
-
-		for _, bug := range updateActualUser.CaughtBug {
-			if bug > maxBugAndFish {
+			if updateActualUser.BugNumber > maxBugAndFish {
 				return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 					"status":  "error",
 					"message": "Bug is out of range (maximum 80 items)",
 					"data":    errActual,
 				})
 			}
+
+			// Fields to update
+			actualUser.CaughtBug = append(actualUser.CaughtBug, updateActualUser.BugNumber)
+
+			database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
+			return c.Status(fiber.StatusOK).JSON(fiber.Map{
+				"status":  "success",
+				"message": "user updated",
+			})
 		}
 
-		// Fields to update
-		actualUser.CaughtBug = updateActualUser.CaughtBug
-
-		claims := token.Claims.(*jwt.RegisteredClaims)
-		database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
-		return c.Status(fiber.StatusOK).JSON(fiber.Map{
-			"status":  "success",
-			"message": "user updated",
-		})
 	}
 }
 
@@ -218,37 +229,42 @@ func UpdateUserSeaCreature(c *fiber.Ctx) error {
 			"message": "unauthenticated",
 		})
 	} else {
-		var updateActualUser models.User
+		claims := token.Claims.(*jwt.RegisteredClaims)
+		database.DB.Db.Where("id=?", claims.Issuer).First(&actualUser)
+
+		type UpdateUserCaughtSeaCreature struct {
+			SeaCreatureNumber int32 `json:"caught_sea_creature"`
+		}
+
+		updateActualUser := new(UpdateUserCaughtSeaCreature)
 		errActual := c.BodyParser(&updateActualUser)
-		if errActual != nil {
+
+		if errActual == nil && updateActualUser.SeaCreatureNumber == 0 {
 			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 				"status":  "error",
 				"message": "Something's wrong with your input",
 				"data":    errActual,
 			})
-		}
+		} else {
+			// Check if updated fields aren't over the maximum range of resources
+			maxSeaCreature := int32(40)
 
-		// Check if updated fields aren't over the maximum range of resources
-		maxSeaCreature := int32(40)
-
-		for _, seaCreature := range updateActualUser.CaughtSeaCreatures {
-			if seaCreature > maxSeaCreature {
+			if updateActualUser.SeaCreatureNumber > maxSeaCreature {
 				return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{
 					"status":  "error",
 					"message": "Sea creature is out of range (maximum 40 items)",
 					"data":    errActual,
 				})
 			}
+
+			// Fields to update
+			actualUser.CaughtSeaCreatures = append(actualUser.CaughtSeaCreatures, updateActualUser.SeaCreatureNumber)
+
+			database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
+			return c.Status(fiber.StatusOK).JSON(fiber.Map{
+				"status":  "success",
+				"message": "user updated",
+			})
 		}
-
-		// Fields to update
-		actualUser.CaughtSeaCreatures = updateActualUser.CaughtSeaCreatures
-
-		claims := token.Claims.(*jwt.RegisteredClaims)
-		database.DB.Db.Where("id=?", claims.Issuer).Updates(&actualUser)
-		return c.Status(fiber.StatusOK).JSON(fiber.Map{
-			"status":  "success",
-			"message": "user updated",
-		})
 	}
 }


### PR DESCRIPTION
# 🚀 Description

![url](https://media.giphy.com/media/fTnmUs24FN1ifdqciN/giphy.gif)
We modify our existing update single item path. To add easily an caught items in database, we can only add an integer in the patch body. 

The modified paths are :
- /user/fish
- /user/bug
- /user/sea-creature

## 👩‍🔬 Comments

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Cleaning (non-breaking change which give more readability and clarity)


## 🎨 Screenshots

This is an exemple of a path which can add a single fish in database 
![image](https://github.com/salace-airline/animalpocketresources/assets/91962602/fdf6df67-8d52-4354-8237-baf3ec658fbf)


## 🗒 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes